### PR TITLE
Add nix sandboxing

### DIFF
--- a/data/hokey-pokey-builder-json.nix
+++ b/data/hokey-pokey-builder-json.nix
@@ -1,0 +1,22 @@
+pkgs: env: dot-cabal: jsonSrc: pkgs.stdenv.mkDerivation {
+    name = "hokey-pokey-build";
+    phases = [ "unpackPhase" "buildPhase" ];
+    unpackPhase = ''
+    mkdir src
+    cd src
+    '' + (pkgs.lib.concatMapStrings ({ filename, contents }: ''
+    cat > ${filename} <<EOF
+    ${contents}
+    EOF
+    '') (builtins.fromJSON jsonSrc));
+
+    buildPhase = ''
+    export PATH=${env}:$PATH
+    export HOME=$(mktemp -d)
+    mkdir $HOME/.cabal
+    ln -s ${dot-cabal}/.cabal/* $HOME/.cabal
+
+    cabal build --ghcjs exe:test
+    find dist-newstyle/build -name "all.js" -path "*/x/*" -exec cp {} $out \;
+    '';
+}

--- a/data/hokey-pokey-builder.nix
+++ b/data/hokey-pokey-builder.nix
@@ -1,0 +1,19 @@
+pkgs: env: dot-cabal: src: pkgs.stdenv.mkDerivation {
+    name = "hokey-pokey-build";
+    phases = [ "unpackPhase" "buildPhase" ];
+    unpackPhase = ''
+    mkdir src
+    cd src
+    cp -r ${src}/* .
+    '';
+
+    buildPhase = ''
+    export PATH=${env}:$PATH
+    export HOME=$(mktemp -d)
+    mkdir $HOME/.cabal
+    ln -s ${dot-cabal}/.cabal/* $HOME/.cabal
+
+    cabal build --ghcjs exe:test
+    find dist-newstyle/build -name "all.js" -path "*/x/*" -exec cp {} $out \;
+    '';
+}

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,8 @@
-{ pkgs ? import nixpkgs (haskellNixpkgsArgs // { inherit system; })
+{ pkgs ? import nixpkgs ({
+  inherit (haskellNixpkgsArgs) config;
+  inherit system;
+  overlays = haskellNixpkgsArgs.overlays ++ extraOverlays;
+  })
 # where
 , nixpkgs ? haskellNix + "/nixpkgs"
 , haskellNixpkgsArgs ? import haskellNix
@@ -10,6 +14,7 @@
   }
 
 , haskellCompiler ? "ghc865"
+, extraOverlays ? []
 }:
 let
   node = pkgs.nodejs-12_x;
@@ -37,13 +42,41 @@ let
     buildInputs = (oldAttrs.buildInputs or []) ++
       [ pkgs.haskell.compiler.ghcjs node ];
   });
+
+  # the envionment hokey-pokey-env depends on.
+  hokey-pokey-env = [ pkgs.haskell.compiler.ghcjs pkgs.haskell-nix.cabal-install node ];
+
+  # the hokey-pokey-dot-cabal state.
+  # if we need newer cabal packages, we need to bump this.
+  hokey-pokey-dot-cabal = pkgs.haskell-nix.dotCabal {
+      index-state = "2019-12-01T00:00:00Z";
+      sha256 = "1akhhhp96qmr4qm7c7z2ij1cwkhw65rz912yl4k92764wgp3jpnd";
+      inherit (pkgs.haskell-nix) cabal-install nix-tools;
+    };
+
+
 in project // rec {
   inherit pkgs;
-  hokey-pokey-env = [ pkgs.haskell.compiler.ghcjs pkgs.haskell-nix.cabal-install node ];
+  hokey-pokey-path = pkgs.lib.makeBinPath hokey-pokey-env;
+  hokey-pokey-drv-json = (import ./data/hokey-pokey-builder-json.nix) pkgs hokey-pokey-path hokey-pokey-dot-cabal;
+
+  # this will generate a standaline script, such that we don't need
+  # to run all of this.  We will then embed it with the hokey-pokey service.
+  hokey-pokey-drv-standalone = pkgs.writeText "hokey-pokey-standalone.nix" ''
+  (import ./hokey-pokey-builder.nix) (import ${haskellNix + "/nixpkgs"} {}) "${hokey-pokey-path}" ${hokey-pokey-dot-cabal}
+  '';
+
+  # test the hokey-pokey-derivation generator.
+  hokey-pokey-drv-test = hokey-pokey-drv-json (builtins.readFile ./test/test.json);
+
+  # wrap hokey-pokey
   hokey-pokey-wrapped = project.hokey-pokey.components.exes.hokey-pokey.overrideAttrs (oldAttrs: {
     nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ pkgs.makeWrapper ];
     postInstall = ''
-        wrapProgram $out/bin/hokey-pokey --prefix PATH ":" ${pkgs.lib.makeBinPath hokey-pokey-env }
+        # embed the .nix scripts into the dataDir. May god have mercy on my soul for I have sinned...
+        DATADIR=$(find $out/share -name "defaultProject" -type d)/..
+        cp ${hokey-pokey-drv-standalone} $DATADIR/hokey-pokey-drv-standalone.nix
+        wrapProgram $out/bin/hokey-pokey --prefix PATH ":" ${pkgs.lib.makeBinPath [ pkgs.nix ]}
       '';
   });
   shell = addGhcjsAndNode (project.shellFor {});

--- a/default.nix
+++ b/default.nix
@@ -17,11 +17,34 @@
 , extraOverlays ? []
 }:
 let
+  # the envionment hokey-pokey-env depends on.
+  hokey-pokey-env = [ pkgs.haskell.compiler.ghcjs pkgs.haskell-nix.cabal-install node ];
+  hokey-pokey-path = pkgs.lib.makeBinPath hokey-pokey-env;
+
+  # the hokey-pokey-dot-cabal state.
+  # if we need newer cabal packages, we need to bump this.
+  hokey-pokey-dot-cabal = pkgs.haskell-nix.dotCabal {
+      index-state = "2019-12-01T00:00:00Z";
+      sha256 = "1akhhhp96qmr4qm7c7z2ij1cwkhw65rz912yl4k92764wgp3jpnd";
+      inherit (pkgs.haskell-nix) cabal-install nix-tools;
+    };
+
+  # this will generate a standaline script, such that we don't need
+  # to run all of this.  We will then embed it with the hokey-pokey service.
+  hokey-pokey-drv-standalone = pkgs.writeText "hokey-pokey-standalone.nix" ''
+  (import ./hokey-pokey-builder.nix) (import ${haskellNix + "/nixpkgs"} {}) "${hokey-pokey-path}" ${hokey-pokey-dot-cabal}
+  '';
+
   node = pkgs.nodejs-12_x;
   project = pkgs.haskell-nix.cabalProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
     ghc = pkgs.haskell-nix.compiler.${haskellCompiler};
     modules = [{
+      packages.hokey-pokey.postInstall = ''
+        # embed the .nix scripts into the dataDir. May god have mercy on my soul for I have sinned...
+        DATADIR=$(find $out/share -name "defaultProject" -type d)/..
+        cp ${hokey-pokey-drv-standalone} $DATADIR/hokey-pokey-drv-standalone.nix
+      '';
       packages.hokey-pokey.components.tests.hokey-pokey-test.preCheck = ''
         export HOME=$(mktemp -d)
         mkdir $HOME/.cabal
@@ -37,34 +60,19 @@ let
     buildInputs = (oldAttrs.buildInputs or []) ++
       [ pkgs.haskell-nix.cabal-install ];
   });
+  addNix = drv: drv.overrideAttrs (oldAttrs: {
+    buildInputs = (oldAttrs.buildInputs or []) ++
+      [ pkgs.nix ];
+  });
   addGhcjsAndNode = drv: drv.overrideAttrs (oldAttrs: {
     # Use nispkgs ghcjs for now
     buildInputs = (oldAttrs.buildInputs or []) ++
       [ pkgs.haskell.compiler.ghcjs node ];
   });
 
-  # the envionment hokey-pokey-env depends on.
-  hokey-pokey-env = [ pkgs.haskell.compiler.ghcjs pkgs.haskell-nix.cabal-install node ];
-
-  # the hokey-pokey-dot-cabal state.
-  # if we need newer cabal packages, we need to bump this.
-  hokey-pokey-dot-cabal = pkgs.haskell-nix.dotCabal {
-      index-state = "2019-12-01T00:00:00Z";
-      sha256 = "1akhhhp96qmr4qm7c7z2ij1cwkhw65rz912yl4k92764wgp3jpnd";
-      inherit (pkgs.haskell-nix) cabal-install nix-tools;
-    };
-
-
 in project // rec {
   inherit pkgs;
-  hokey-pokey-path = pkgs.lib.makeBinPath hokey-pokey-env;
   hokey-pokey-drv-json = (import ./data/hokey-pokey-builder-json.nix) pkgs hokey-pokey-path hokey-pokey-dot-cabal;
-
-  # this will generate a standaline script, such that we don't need
-  # to run all of this.  We will then embed it with the hokey-pokey service.
-  hokey-pokey-drv-standalone = pkgs.writeText "hokey-pokey-standalone.nix" ''
-  (import ./hokey-pokey-builder.nix) (import ${haskellNix + "/nixpkgs"} {}) "${hokey-pokey-path}" ${hokey-pokey-dot-cabal}
-  '';
 
   # test the hokey-pokey-derivation generator.
   hokey-pokey-drv-test = hokey-pokey-drv-json (builtins.readFile ./test/test.json);
@@ -81,7 +89,7 @@ in project // rec {
   });
   shell = addGhcjsAndNode (project.shellFor {});
   checks = pkgs.recurseIntoAttrs {
-    hokey-pokey-test = addCabalInstall
+    hokey-pokey-test = addNix
       (addGhcjsAndNode project.hokey-pokey.checks.hokey-pokey-test);
   };
 }

--- a/hokey-pokey.cabal
+++ b/hokey-pokey.cabal
@@ -15,6 +15,8 @@ extra-source-files:
 data-dir: data
 data-files:
   defaultProject/cabal.project
+  ./hokey-pokey-builder-json.nix
+  ./hokey-pokey-builder.nix
 
 source-repository head
   type: git

--- a/hokey-pokey.cabal
+++ b/hokey-pokey.cabal
@@ -15,8 +15,8 @@ extra-source-files:
 data-dir: data
 data-files:
   defaultProject/cabal.project
-  ./hokey-pokey-builder-json.nix
-  ./hokey-pokey-builder.nix
+  hokey-pokey-builder-json.nix
+  hokey-pokey-builder.nix
 
 source-repository head
   type: git

--- a/test/test.json
+++ b/test/test.json
@@ -1,0 +1,8 @@
+[
+    { "filename": "test.cabal"
+    , "contents": "cabal-version:  1.12\nname:           test\nversion:        0.1.0.0\nbuild-type:     Simple\nexecutable test\n  main-is: Main.hs\n  build-depends:\n      base >=4.7 && <5\n  default-language: Haskell2010\n"
+    },
+    { "filename": "Main.hs"
+    , "contents": "module Main where\n\nmain = putStrLn \"Hello from hokey-pokey\" \n"
+    }
+]


### PR DESCRIPTION
This adds logic to sandbox the build with `nix-build`. The downside is that we go from ~3s to ~10s :-/

Also it will likely only work for standard modules right now, the package-name lookup is gone. We can't run tests anymore as that now requires recursive nix; we are executing nix while running a check under nix 🤷‍♂.